### PR TITLE
Explicitly set work queue name to None

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -477,6 +477,7 @@ class Flow(Generic[P, R]):
         deployment = await Deployment.build_from_flow(
             self,
             name=name,
+            work_queue_name=None,
             apply=False,
             skip_upload=True,
             load_existing=False,


### PR DESCRIPTION
The "default" queue name was being set client-side, which ultimately triggered work pool creation and assignment.  Setting the queue to `None` explicitly avoids any pool assignment.