### PR TITLE
Add `prefect flow serve` CLI

### DIFF
--- a/src/prefect/cli/flow.py
+++ b/src/prefect/cli/flow.py
@@ -2,12 +2,28 @@
 Command line interface for working with flows.
 """
 
+import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+from rich.panel import Panel
 from rich.table import Table
 
 from prefect.cli._types import PrefectTyper
+from prefect.cli._utilities import exit_with_error
 from prefect.cli.root import app
 from prefect.client import get_client
+from prefect.client.schemas.schedules import (
+    CronSchedule,
+    IntervalSchedule,
+    RRuleSchedule,
+)
 from prefect.client.schemas.sorting import FlowSort
+from prefect.deployments.runner import RunnerDeployment
+from prefect.exceptions import MissingFlowError
+from prefect.flows import load_flow_from_entrypoint
+from prefect.runner import Runner
 
 flow_app = PrefectTyper(name="flow", help="Commands for interacting with flows.")
 app.add_typer(flow_app, aliases=["flows"])
@@ -39,3 +55,127 @@ async def ls(
         )
 
     app.console.print(table)
+
+
+@flow_app.command()
+async def serve(
+    entrypoint: str = typer.Argument(
+        None,
+        help=(
+            "The path to a file containing a flow and the name of the flow function in"
+            " the format `./path/to/file.py:flow_func_name`."
+        ),
+    ),
+    name: str = typer.Option(
+        ...,
+        "--name",
+        "-n",
+        help="The name to give the deployment created for the flow.",
+    ),
+    description: Optional[str] = typer.Option(
+        None,
+        "--description",
+        "-d",
+        help=(
+            "The description to give the created deployment. If not provided, the"
+            " description will be populated from the flow's description."
+        ),
+    ),
+    version: Optional[str] = typer.Option(
+        None, "-v", "--version", help="A version to give the created deployment."
+    ),
+    tags: Optional[List[str]] = typer.Option(
+        ...,
+        "-t",
+        "--tag",
+        default_factory=list,
+        help="One or more optional tags to apply to the created deployment.",
+    ),
+    cron: Optional[str] = typer.Option(
+        None,
+        "--cron",
+        help=(
+            "A cron string that will be used to set a schedule for the created"
+            " deployment."
+        ),
+    ),
+    interval: Optional[int] = typer.Option(
+        None,
+        "--interval",
+        help=(
+            "An integer specifying an interval (in seconds) between scheduled runs of"
+            " the flow."
+        ),
+    ),
+    interval_anchor: Optional[str] = typer.Option(
+        None, "--anchor-date", help="The start date for an interval schedule."
+    ),
+    rrule: Optional[str] = typer.Option(
+        None,
+        "--rrule",
+        help="An RRule that will be used to set a schedule for the created deployment.",
+    ),
+    timezone: Optional[str] = typer.Option(
+        None,
+        "--timezone",
+        help="Timezone to used scheduling flow runs e.g. 'America/New_York'",
+    ),
+    pause_on_shutdown: bool = typer.Option(
+        True,
+        help=(
+            "If set, provided schedule will be paused when the serve command is"
+            " stopped. If not set, the schedules will continue running."
+        ),
+    ),
+):
+    """
+    Serve a flow via an entrypoint.
+    """
+    try:
+        flow = load_flow_from_entrypoint(entrypoint)
+    except MissingFlowError as exc:
+        exit_with_error(str(exc))
+
+    num_schedules = sum(
+        1 for schedule in (interval, cron, rrule) if schedule is not None
+    )
+    if num_schedules > 1:
+        raise ValueError("Only one of interval, cron, and rrule can be provided.")
+
+    if interval_anchor and not interval:
+        raise ValueError(
+            "An anchor date can only be provided with an interval schedule"
+        )
+
+    schedule = None
+    if interval:
+        schedule = IntervalSchedule(
+            interval=datetime.timedelta(seconds=interval),
+            anchor_date=interval_anchor,
+            timezone=timezone,
+        )
+    elif cron:
+        schedule = CronSchedule(cron=cron, timezone=timezone)
+    elif rrule:
+        schedule = RRuleSchedule(rrule=rrule, timezone=timezone)
+
+    if tags is None:
+        tags = []
+
+    runner = Runner(name=name, pause_on_shutdown=pause_on_shutdown)
+    runner_deployment = await RunnerDeployment.from_flow(
+        flow=flow,
+        name=name,
+        entrypoint=entrypoint,
+        path=str(Path.cwd()),
+        schedule=schedule,
+        description=description,
+        tags=tags,
+        version=version,
+    )
+    await runner.add_deployment(runner_deployment)
+    app.console.print(
+        Panel(f"Your flow {flow.name!r} is served and polling for scheduled runs!"),
+        style="blue",
+    )
+    await runner.start()

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -184,14 +184,13 @@ class RunnerDeployment(BaseModel):
 
         return schedule
 
-    @staticmethod
-    def set_defaults_from_flow(deployment, flow: Flow):
-        deployment.parameter_openapi_schema = parameter_schema(flow)
+    def _set_defaults_from_flow(self, flow: Flow):
+        self.parameter_openapi_schema = parameter_schema(flow)
 
-        if not deployment.version:
-            deployment.version = flow.version
-        if not deployment.description:
-            deployment.description = flow.description
+        if not self.version:
+            self.version = flow.version
+        if not self.description:
+            self.description = flow.description
 
     @classmethod
     @sync_compatible
@@ -269,7 +268,7 @@ class RunnerDeployment(BaseModel):
             entry_path = Path(flow_file).absolute().relative_to(Path(".").absolute())
             deployment.entrypoint = f"{entry_path}:{flow.fn.__name__}"
 
-        cls.set_defaults_from_flow(deployment, flow)
+        cls._set_defaults_from_flow(deployment, flow)
 
         if apply:
             await deployment.apply()
@@ -339,7 +338,7 @@ class RunnerDeployment(BaseModel):
             path=str(Path.cwd()),
         )
 
-        cls.set_defaults_from_flow(deployment, flow)
+        cls._set_defaults_from_flow(deployment, flow)
 
         if apply:
             await deployment.apply()

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -3,19 +3,24 @@ Objects for specifying deployments and utilities for loading flows from deployme
 """
 
 import importlib
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import partial
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
 import pendulum
 from pydantic import BaseModel, Field, validator
 
 from prefect.client.orchestration import ServerType, get_client
-from prefect.client.schemas.schedules import SCHEDULE_TYPES
+from prefect.client.schemas.schedules import (
+    SCHEDULE_TYPES,
+    CronSchedule,
+    IntervalSchedule,
+    RRuleSchedule,
+)
 from prefect.events.schemas import DeploymentTrigger
-from prefect.flows import Flow
+from prefect.flows import Flow, load_flow_from_entrypoint
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.callables import ParameterSchema, parameter_schema
 
@@ -57,7 +62,7 @@ class RunnerDeployment(BaseModel):
         default_factory=list,
         description="One of more tags to apply to this deployment.",
     )
-    schedule: SCHEDULE_TYPES = None
+    schedule: Optional[SCHEDULE_TYPES] = None
     is_schedule_active: Optional[bool] = Field(
         default=None, description="Whether or not the schedule is active."
     )
@@ -144,14 +149,67 @@ class RunnerDeployment(BaseModel):
 
             return deployment_id
 
+    @staticmethod
+    def _construct_schedule(
+        interval: Optional[Union[int, float, timedelta]] = None,
+        anchor_date: Optional[Union[str, datetime]] = None,
+        cron: Optional[str] = None,
+        rrule: Optional[str] = None,
+        timezone: Optional[str] = None,
+    ) -> Optional[SCHEDULE_TYPES]:
+        schedule = None
+
+        num_schedules = sum(
+            1 for schedule in (interval, cron, rrule) if schedule is not None
+        )
+        if num_schedules > 1:
+            raise ValueError("Only one of interval, cron, and rrule can be provided.")
+
+        if anchor_date and not interval:
+            raise ValueError(
+                "An anchor date can only be provided with an interval schedule"
+            )
+
+        schedule = None
+        if interval:
+            if isinstance(interval, (int, float)):
+                interval = timedelta(seconds=interval)
+            schedule = IntervalSchedule(
+                interval=interval, anchor_date=anchor_date, timezone=timezone
+            )
+        elif cron:
+            schedule = CronSchedule(cron=cron, timezone=timezone)
+        elif rrule:
+            schedule = RRuleSchedule(rrule=rrule, timezone=timezone)
+
+        return schedule
+
+    @staticmethod
+    def set_defaults_from_flow(deployment, flow: Flow):
+        deployment.parameter_openapi_schema = parameter_schema(flow)
+
+        if not deployment.version:
+            deployment.version = flow.version
+        if not deployment.description:
+            deployment.description = flow.description
+
     @classmethod
     @sync_compatible
     async def from_flow(
         cls,
         flow: Flow,
         name: str,
+        interval: Optional[Union[int, float, timedelta]] = None,
+        anchor_date: Optional[Union[str, datetime]] = None,
+        cron: Optional[str] = None,
+        rrule: Optional[str] = None,
+        timezone: Optional[str] = None,
+        parameters: Optional[dict] = None,
+        triggers: Optional[List[DeploymentTrigger]] = None,
+        description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        version: Optional[str] = None,
         apply: bool = False,
-        **kwargs,
     ) -> "RunnerDeployment":
         """
         Configure a deployment for a given flow.
@@ -159,11 +217,40 @@ class RunnerDeployment(BaseModel):
         Args:
             flow: A flow function to deploy
             name: A name for the deployment
+            interval: An interval on which to execute the current flow. Accepts either a number
+                or a timedelta object. If a number is given, it will be interpreted as seconds.
+            anchor_date: The start date for an interval schedule.
+            cron: A cron schedule of when to execute runs of this flow.
+            rrule: An rrule schedule of when to execute runs of this flow.
+            timezone: Timezone to used scheduling flow runs e.g. 'America/New_York'
+            triggers: A list of triggers that should kick of a run of this flow.
+            parameters: A dictionary of default parameter values to pass to runs of this flow.
+            description: A description for the created deployment. Defaults to the flow's
+                description if not provided.
+            tags: A list of tags to associate with the created deployment for organizational
+                purposes.
+            version: A version for the created deployment. Defaults to the flow's version.
             apply: If True, the deployment is automatically registered with the API
-            **kwargs: Other keyword arguments to pass to the constructor for the
-                `RunnerDeployment` class
         """
-        deployment = cls(name=name, flow_name=flow.name, **kwargs)
+        schedule = cls._construct_schedule(
+            interval=interval,
+            anchor_date=anchor_date,
+            cron=cron,
+            rrule=rrule,
+            timezone=timezone,
+        )
+
+        deployment = cls(
+            name=name,
+            flow_name=flow.name,
+            schedule=schedule,
+            tags=tags or [],
+            triggers=triggers or [],
+            parameters=parameters or {},
+            description=description,
+            version=version,
+        )
+
         # TODO: better error messages with doc links
         if not deployment.entrypoint:
             ## first see if an entrypoint can be determined
@@ -182,13 +269,77 @@ class RunnerDeployment(BaseModel):
             entry_path = Path(flow_file).absolute().relative_to(Path(".").absolute())
             deployment.entrypoint = f"{entry_path}:{flow.fn.__name__}"
 
-        # set a few attributes for this flow object
-        deployment.parameter_openapi_schema = parameter_schema(flow)
+        cls.set_defaults_from_flow(deployment, flow)
 
-        if not deployment.version:
-            deployment.version = flow.version
-        if not deployment.description:
-            deployment.description = flow.description
+        if apply:
+            await deployment.apply()
+
+        return deployment
+
+    @classmethod
+    @sync_compatible
+    async def from_entrypoint(
+        cls,
+        entrypoint: str,
+        name: str,
+        interval: Optional[Union[int, float, timedelta]] = None,
+        anchor_date: Optional[Union[str, datetime]] = None,
+        cron: Optional[str] = None,
+        rrule: Optional[str] = None,
+        timezone: Optional[str] = None,
+        parameters: Optional[dict] = None,
+        triggers: Optional[List[DeploymentTrigger]] = None,
+        description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        version: Optional[str] = None,
+        apply: bool = False,
+    ) -> "RunnerDeployment":
+        """
+        Configure a deployment for a given flow located at a given entrypoint.
+
+        Args:
+            entrypoint:  The path to a file containing a flow and the name of the flow function in
+                the format `./path/to/file.py:flow_func_name`.
+            name: A name for the deployment
+            interval: An interval on which to execute the current flow. Accepts either a number
+                or a timedelta object. If a number is given, it will be interpreted as seconds.
+            anchor_date: The start date for an interval schedule.
+            cron: A cron schedule of when to execute runs of this flow.
+            rrule: An rrule schedule of when to execute runs of this flow.
+            timezone: Timezone to used scheduling flow runs e.g. 'America/New_York'
+            triggers: A list of triggers that should kick of a run of this flow.
+            parameters: A dictionary of default parameter values to pass to runs of this flow.
+            description: A description for the created deployment. Defaults to the flow's
+                description if not provided.
+            tags: A list of tags to associate with the created deployment for organizational
+                purposes.
+            version: A version for the created deployment. Defaults to the flow's version.
+            apply: If True, the deployment is automatically registered with the API
+        """
+        flow = load_flow_from_entrypoint(entrypoint)
+
+        schedule = cls._construct_schedule(
+            interval=interval,
+            anchor_date=anchor_date,
+            cron=cron,
+            rrule=rrule,
+            timezone=timezone,
+        )
+
+        deployment = cls(
+            name=name,
+            flow_name=flow.name,
+            schedule=schedule,
+            tags=tags or [],
+            triggers=triggers or [],
+            parameters=parameters or {},
+            description=description,
+            version=version,
+            entrypoint=entrypoint,
+            path=str(Path.cwd()),
+        )
+
+        cls.set_defaults_from_flow(deployment, flow)
 
         if apply:
             await deployment.apply()

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -645,7 +645,7 @@ class Flow(Generic[P, R]):
             console = Console()
             console.print(
                 Panel(
-                    f"Your flow {self.name!r} is served and ready for scheduled runs!"
+                    f"Your flow {self.name!r} is served and polling for scheduled runs!"
                 ),
                 style="blue",
             )

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -41,11 +41,6 @@ from prefect._internal.compatibility.experimental import experimental
 from prefect._internal.schemas.validators import raise_on_name_with_banned_characters
 from prefect.client.schemas.objects import Flow as FlowSchema
 from prefect.client.schemas.objects import FlowRun
-from prefect.client.schemas.schedules import (
-    CronSchedule,
-    IntervalSchedule,
-    RRuleSchedule,
-)
 from prefect.context import PrefectObjectRegistry, registry_from_script
 from prefect.events.schemas import DeploymentTrigger
 from prefect.exceptions import (
@@ -525,39 +520,18 @@ class Flow(Generic[P, R]):
         """
         from prefect.deployments.runner import RunnerDeployment
 
-        num_schedules = sum(
-            1 for schedule in (interval, cron, rrule) if schedule is not None
-        )
-        if num_schedules > 1:
-            raise ValueError("Only one of interval, cron, and rrule can be provided.")
-
-        schedule = None
-        if interval:
-            if isinstance(interval, (int, float)):
-                interval = datetime.timedelta(seconds=interval)
-            schedule = IntervalSchedule(interval=interval)
-        elif cron:
-            schedule = CronSchedule(cron=cron)
-        elif rrule:
-            schedule = RRuleSchedule(rrule=rrule)
-
-        if tags is None:
-            tags = []
-
-        if triggers is None:
-            triggers = []
-
-        init_kwargs = dict(
+        return await RunnerDeployment.from_flow(
+            self,
             name=name,
-            schedule=schedule,
+            interval=interval,
+            cron=cron,
+            rrule=rrule,
             tags=tags,
             triggers=triggers,
             parameters=parameters or {},
             description=description,
             version=version,
         )
-
-        return await RunnerDeployment.from_flow(self, **init_kwargs)
 
     @sync_compatible
     async def serve(


### PR DESCRIPTION
Adds a CLI to serve a flow via an entrypoint.

Example:
```bash
prefect flow serve -n test-serve-cli serve_demo.py:tired_flow
```